### PR TITLE
最大化時にWindowの端が見切れるのを修正。Windowタイトルと最小サイズ追加

### DIFF
--- a/BrainfuckIDE/MainWindow.xaml
+++ b/BrainfuckIDE/MainWindow.xaml
@@ -13,13 +13,14 @@
         xmlns:interpreter="clr-namespace:Interpreter;assembly=Interpreter"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         mc:Ignorable="d"
-        Title="MainWindow" Height="650" Width="1000"
+        Title="Brainfuck IDE" Height="650" Width="1000"
         d:DataContext="{d:DesignInstance {x:Type vm:InterpreterRunningViewModel}}"
         dd:DragDrop.IsDropTarget="True"  
         dd:DragDrop.DropHandler="{Binding EditrVM}" 
-        Background="#FF3F3F46"
+        Background="Transparent"
         WindowStyle="None" 
         Loaded="Window_Loaded"
+        AllowsTransparency="True" MinWidth="300" MinHeight="40"
         >
 
     <Window.CommandBindings>
@@ -41,93 +42,104 @@
         <ResourceDictionary Source="/ControlStyle/StyleDictionary.xaml"/>
     </Window.Resources>
 
-    <Grid Background="Transparent">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="30"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-        <DockPanel>
-            <StackPanel DockPanel.Dock="Right"
+    <Border BorderBrush="Transparent" Background="#FF3F3F46">
+        <Border.Style>
+            <Style TargetType="{x:Type Border}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding WindowState, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}" Value="{x:Static WindowState.Maximized}">
+                        <Setter Property="BorderThickness" Value="7"/>
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </Border.Style>
+        <Grid Background="Transparent">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Right"
                     Margin="0,0,5,0"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right">
-                <Button Content="0" Style="{DynamicResource CaptionButtonStyleKey}" Command="{x:Static SystemCommands.MinimizeWindowCommand}"/>
-                <Button Content="1" Style="{DynamicResource CaptionButtonStyleKey}" Command="{x:Static SystemCommands.MaximizeWindowCommand}">
-                    <Button.Visibility>
-                        <Binding RelativeSource="{RelativeSource AncestorType=Window}"  
+                    <Button Content="0" Style="{DynamicResource CaptionButtonStyleKey}" Command="{x:Static SystemCommands.MinimizeWindowCommand}"/>
+                    <Button Content="1" Style="{DynamicResource CaptionButtonStyleKey}" Command="{x:Static SystemCommands.MaximizeWindowCommand}">
+                        <Button.Visibility>
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}"  
                          Path="WindowState"  
                          Mode="OneWay"  
                          Converter="{ctrls:EqualsToVisibleConveter}">
-                            <Binding.ConverterParameter>
-                                <WindowState>Normal</WindowState>
-                            </Binding.ConverterParameter>
-                        </Binding>
-                    </Button.Visibility>
-                </Button>
-                <Button Content="2" Style="{DynamicResource CaptionButtonStyleKey}"  Command="{x:Static SystemCommands.RestoreWindowCommand}">
-                    <Button.Visibility>
-                        <Binding RelativeSource="{RelativeSource AncestorType=Window}"  
+                                <Binding.ConverterParameter>
+                                    <WindowState>Normal</WindowState>
+                                </Binding.ConverterParameter>
+                            </Binding>
+                        </Button.Visibility>
+                    </Button>
+                    <Button Content="2" Style="{DynamicResource CaptionButtonStyleKey}"  Command="{x:Static SystemCommands.RestoreWindowCommand}">
+                        <Button.Visibility>
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}"  
                          Path="WindowState"  
                          Mode="OneWay"  
                          Converter="{ctrls:EqualsToVisibleConveter}">
-                            <Binding.ConverterParameter>
-                                <WindowState>Maximized</WindowState>
-                            </Binding.ConverterParameter>
-                        </Binding>
-                    </Button.Visibility>
-                </Button>
-                <Button Content="r" Style="{DynamicResource CaptionButtonStyleKey}" Command="{x:Static SystemCommands.CloseWindowCommand}"/>
-            </StackPanel>
-            <Menu Background="#FF3F3F46" Foreground="White" Margin="30,2,2,2" DockPanel.Dock="Left" HorizontalAlignment="Left" VerticalAlignment="Bottom" 
+                                <Binding.ConverterParameter>
+                                    <WindowState>Maximized</WindowState>
+                                </Binding.ConverterParameter>
+                            </Binding>
+                        </Button.Visibility>
+                    </Button>
+                    <Button Content="r" Style="{DynamicResource CaptionButtonStyleKey}" Command="{x:Static SystemCommands.CloseWindowCommand}"/>
+                </StackPanel>
+                <Menu Background="#FF3F3F46" Foreground="White" Margin="30,2,2,2" DockPanel.Dock="Left" HorizontalAlignment="Left" VerticalAlignment="Bottom" 
               WindowChrome.IsHitTestVisibleInChrome="True">
-                <!--<MenuItem Header="File(_F)"  Background="#FF3F3F46" Foreground="White">
+                    <!--<MenuItem Header="File(_F)"  Background="#FF3F3F46" Foreground="White">
                 <MenuItem Header="Empty"  Background="#FF3F3F46"/>
             </MenuItem>-->
-                <MenuItem Header="Refact(_R)" Foreground="White" Template="{StaticResource MenuItemControlTemplate}">
-                    <MenuItem Header="CopySimplyCodeToClipbord"  Background="#FF3F3F46" Command="{Binding CopySimplyCodeToClipbordCommand}"/>
-                </MenuItem>
-                <MenuItem Header="Window(_W)" Foreground="White" Template="{StaticResource MenuItemControlTemplate}">
-                    <MenuItem Header="Print text code geter window"  Background="#FF3F3F46" Command="{Binding OpenPrintTextCodeGeterWindowCommand}"/>
-                </MenuItem>
-            </Menu>
-        </DockPanel>
-        <Grid Grid.Row="2" Margin="5,0,5,5"  Background="#FF2D2D30" >
-            <Grid.InputBindings>
-                <KeyBinding Gesture="Ctrl+S" Command="{Binding EditrVM.SaveCommand}"/>
-                <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding EditrVM.SaveAsCommand}"/>
-                <KeyBinding Gesture="F5" Command="{Binding RunCommand}" CommandParameter="{x:Static interpreter:RunType.Nomal}"/>
-                <KeyBinding Gesture="Shift+F5" Command="{Binding RaiseStopReqestCommand}"/>
-                <KeyBinding Gesture="F11" Command="{Binding RunCommand}" CommandParameter="{x:Static interpreter:RunType.OneStep}"/>
-            </Grid.InputBindings>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition MinWidth="100"/>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="300"/>
-            </Grid.ColumnDefinitions>
-            <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" Background="#FF3F3F46" />
-            <Grid Grid.Column="0">
-                <Grid.RowDefinitions>
-                    <RowDefinition MinHeight="100"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition MinHeight="100"/>
-                </Grid.RowDefinitions>
-                <GridSplitter Grid.Row="1" Height="5" HorizontalAlignment="Stretch"  Background="#FF3F3F46"/>
-                <editor:EditorLayer Grid.Row="0" DataContext="{Binding EditrVM, Mode=OneTime}"/>
-                <view:MemoryViewLayer Grid.Row="2" DataContext="{Binding MemoryVM, Mode=OneTime}" Margin="5"/>
-            </Grid>
-            <Grid Grid.Column="2" >
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="170"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition MinHeight="100"/>
-                </Grid.RowDefinitions>
-                <GridSplitter Grid.Row="2" Height="5" HorizontalAlignment="Stretch"  Background="#FF3F3F46"/>
-                <view:CommandPanel Grid.Row="0"/>
-                <view:TextInputViewPanel Grid.Row="1" Margin="10" DataContext="{Binding TextImputDataVM, Mode=OneTime}"/>
-                <view:ResultViewLayer Grid.Row="3" Margin="5" DataContext="{Binding ResultTextVM, Mode=OneTime}"/>
+                    <MenuItem Header="Refact(_R)" Foreground="White" Template="{StaticResource MenuItemControlTemplate}">
+                        <MenuItem Header="CopySimplyCodeToClipbord"  Background="#FF3F3F46" Command="{Binding CopySimplyCodeToClipbordCommand}"/>
+                    </MenuItem>
+                    <MenuItem Header="Window(_W)" Foreground="White" Template="{StaticResource MenuItemControlTemplate}">
+                        <MenuItem Header="Print text code geter window"  Background="#FF3F3F46" Command="{Binding OpenPrintTextCodeGeterWindowCommand}"/>
+                    </MenuItem>
+                </Menu>
+            </DockPanel>
+            <Grid Grid.Row="2" Margin="5,0,5,5"  Background="#FF2D2D30" >
+                <Grid.InputBindings>
+                    <KeyBinding Gesture="Ctrl+S" Command="{Binding EditrVM.SaveCommand}"/>
+                    <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding EditrVM.SaveAsCommand}"/>
+                    <KeyBinding Gesture="F5" Command="{Binding RunCommand}" CommandParameter="{x:Static interpreter:RunType.Nomal}"/>
+                    <KeyBinding Gesture="Shift+F5" Command="{Binding RaiseStopReqestCommand}"/>
+                    <KeyBinding Gesture="F11" Command="{Binding RunCommand}" CommandParameter="{x:Static interpreter:RunType.OneStep}"/>
+                </Grid.InputBindings>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition MinWidth="100"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="300"/>
+                </Grid.ColumnDefinitions>
+                <GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Stretch" Background="#FF3F3F46" />
+                <Grid Grid.Column="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition MinHeight="100"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition MinHeight="100"/>
+                    </Grid.RowDefinitions>
+                    <GridSplitter Grid.Row="1" Height="5" HorizontalAlignment="Stretch"  Background="#FF3F3F46"/>
+                    <editor:EditorLayer Grid.Row="0" DataContext="{Binding EditrVM, Mode=OneTime}"/>
+                    <view:MemoryViewLayer Grid.Row="2" DataContext="{Binding MemoryVM, Mode=OneTime}" Margin="5"/>
+                </Grid>
+                <Grid Grid.Column="2" >
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="170"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition MinHeight="100"/>
+                    </Grid.RowDefinitions>
+                    <GridSplitter Grid.Row="2" Height="5" HorizontalAlignment="Stretch"  Background="#FF3F3F46"/>
+                    <view:CommandPanel Grid.Row="0"/>
+                    <view:TextInputViewPanel Grid.Row="1" Margin="10" DataContext="{Binding TextImputDataVM, Mode=OneTime}"/>
+                    <view:ResultViewLayer Grid.Row="3" Margin="5" DataContext="{Binding ResultTextVM, Mode=OneTime}"/>
+                </Grid>
             </Grid>
         </Grid>
-    </Grid>
+    </Border>
 </Window>


### PR DESCRIPTION
# MainWindowのレイアウト

## 最大化時にWindow端が画面外に見切れる

WindowChromeを用いて独自のウィンドウスタイルを作ると、最大化時にWindowが7ピクセルだけ画面外に見切れてしまう問題がある。

Windowのroot要素にBorderを追加し、最大化時にのみ```Border.BorderThickness="7"```のBorderが出るようにすることでこの問題を解決できる。

変更点は```Window.Background="Transparent"```と```Window.AllowsTransparency="True"```を追加し、rootに上記のBorderを追加、```Border.Background="<もとのWindowの背景色>"```にした点。

root要素にBorderを加えたことで、それ以下のxamlの要素のインデントが下がるため、diffのアルゴリズムによっては大量の変更点が存在するように見えるがインデントが下がっただけである。

## その他

```Window.WindowStyle="None"```にしているためWindowタイトルはWindowには表示されないため忘れがちだが、Windowsのタスクバーやタスクマネージャには```"MainWindow"```というタイトルが表示されてしまうため、タイトルを```"Brainfuck IED"```に変更した。

```Window.WindowStyle="None"```にしていると、Windowのサイズを最小までドラッグして小さくすると、小さくなりすぎてWindowがどこに行ったのか見失う程度に小さくなってしまう(10x10pix程度)ため、最小サイズを適当につけた。

